### PR TITLE
test: add integration tests for Work Categories and Work Logs APIs (Issue #20)

### DIFF
--- a/app/api/work-categories/[id]/__tests__/route.test.ts
+++ b/app/api/work-categories/[id]/__tests__/route.test.ts
@@ -1,0 +1,481 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DELETE, PUT } from "../route";
+
+// Mock the auth module
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+// Mock the repository
+vi.mock("@/lib/db/repositories/work-category-repository", () => ({
+  getWorkCategoryById: vi.fn(),
+  updateWorkCategory: vi.fn(),
+  deleteWorkCategory: vi.fn(),
+  workCategoryNameExists: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import {
+  deleteWorkCategory,
+  getWorkCategoryById,
+  updateWorkCategory,
+  workCategoryNameExists,
+} from "@/lib/db/repositories/work-category-repository";
+
+describe("PUT /api/work-categories/[id]", () => {
+  const validUuid = "123e4567-e89b-12d3-a456-426614174000";
+  const mockCategory = {
+    id: validUuid,
+    name: "Development",
+    description: "Development work",
+    displayOrder: 0,
+    isActive: true,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when user is not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when user is not admin", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 400 for invalid UUID format", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+
+    const invalidId = "invalid-uuid";
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${invalidId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: invalidId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INVALID_ID");
+  });
+
+  it("should return 404 when work category not found", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(undefined);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should update work category successfully", async () => {
+    const updatedCategory = {
+      ...mockCategory,
+      name: "Updated Category",
+      updatedAt: new Date(),
+    };
+
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(mockCategory);
+    vi.mocked(workCategoryNameExists).mockResolvedValue(false);
+    vi.mocked(updateWorkCategory).mockResolvedValue(updatedCategory);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.name).toBe("Updated Category");
+  });
+
+  it("should return 400 when name already exists", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(mockCategory);
+    vi.mocked(workCategoryNameExists).mockResolvedValue(true);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Existing Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("DUPLICATE_NAME");
+  });
+
+  it("should update displayOrder successfully", async () => {
+    const updatedCategory = {
+      ...mockCategory,
+      displayOrder: 5,
+      updatedAt: new Date(),
+    };
+
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(mockCategory);
+    vi.mocked(updateWorkCategory).mockResolvedValue(updatedCategory);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ displayOrder: 5 }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.displayOrder).toBe(5);
+  });
+
+  it("should return 400 for validation errors", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(mockCategory);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "" }), // Invalid: empty name
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("should return 500 when repository throws error", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockRejectedValue(
+      new Error("Database error"),
+    );
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated Category" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INTERNAL_ERROR");
+  });
+});
+
+describe("DELETE /api/work-categories/[id]", () => {
+  const validUuid = "123e4567-e89b-12d3-a456-426614174000";
+  const mockCategory = {
+    id: validUuid,
+    name: "Development",
+    description: "Development work",
+    displayOrder: 0,
+    isActive: true,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when user is not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when user is not admin", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 400 for invalid UUID format", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+
+    const invalidId = "invalid-uuid";
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${invalidId}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: invalidId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INVALID_ID");
+  });
+
+  it("should return 404 when work category not found", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(undefined);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should soft delete work category successfully", async () => {
+    const deletedCategory = {
+      ...mockCategory,
+      isActive: false,
+      updatedAt: new Date(),
+    };
+
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockResolvedValue(mockCategory);
+    vi.mocked(deleteWorkCategory).mockResolvedValue(deletedCategory);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(deleteWorkCategory).toHaveBeenCalledWith(validUuid);
+  });
+
+  it("should return 500 when repository throws error", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkCategoryById).mockRejectedValue(
+      new Error("Database error"),
+    );
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-categories/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/app/api/work-categories/__tests__/route.test.ts
+++ b/app/api/work-categories/__tests__/route.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * Integration tests for Work Categories API (Collection Routes)
+ * Tests GET and POST endpoints with authentication, authorization, and validation
+ */
+
+// Mock dependencies - must be before imports
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+vi.mock("@/lib/db/repositories/work-category-repository", () => ({
+  getAllWorkCategories: vi.fn(),
+  createWorkCategory: vi.fn(),
+  workCategoryNameExists: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import { GET, POST } from "@/app/api/work-categories/route";
+import {
+  getAllWorkCategories,
+  createWorkCategory,
+  workCategoryNameExists,
+} from "@/lib/db/repositories/work-category-repository";
+
+describe("Work Categories API - Collection Routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/work-categories", () => {
+    it("should return 401 if user is not authenticated", async () => {
+      vi.mocked(auth).mockResolvedValue(null as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should return all active work categories when active=true", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockCategories = [
+        {
+          id: "cat-1",
+          name: "Development",
+          description: "Development work",
+          displayOrder: 0,
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: "cat-2",
+          name: "Meeting",
+          description: "Meetings",
+          displayOrder: 1,
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      vi.mocked(getAllWorkCategories).mockResolvedValue(mockCategories);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/work-categories?active=true",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(2);
+      expect(getAllWorkCategories).toHaveBeenCalledWith({
+        activeOnly: true,
+      });
+    });
+
+    it("should return all work categories when active=false", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "admin" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      vi.mocked(getAllWorkCategories).mockResolvedValue([]);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/work-categories?active=false",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(getAllWorkCategories).toHaveBeenCalledWith({
+        activeOnly: false,
+      });
+    });
+
+    it("should handle validation errors in query parameters", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      // This shouldn't cause an error as the schema transforms invalid values to false
+      const request = new NextRequest(
+        "http://localhost:3000/api/work-categories?active=invalid",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("POST /api/work-categories", () => {
+    it("should return 401 if user is not authenticated", async () => {
+      vi.mocked(auth).mockResolvedValue(null as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "New Category",
+          description: "Test category",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should return 403 if user is not admin", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "New Category",
+          description: "Test category",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should create work category with valid data", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "admin-id", email: "admin@example.com", role: "admin" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      vi.mocked(workCategoryNameExists).mockResolvedValue(false);
+
+      const mockCategory = {
+        id: "cat-id",
+        name: "New Category",
+        description: "Test category",
+        displayOrder: 0,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      vi.mocked(createWorkCategory).mockResolvedValue(mockCategory);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "New Category",
+          description: "Test category",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(data.data.name).toBe("New Category");
+    });
+
+    it("should return 400 for duplicate category name", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "admin-id", email: "admin@example.com", role: "admin" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      vi.mocked(workCategoryNameExists).mockResolvedValue(true);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Existing Category",
+          description: "Test category",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("DUPLICATE_NAME");
+    });
+
+    it("should return 400 for invalid request data", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "admin-id", email: "admin@example.com", role: "admin" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "", // Empty name should fail validation
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should apply default values for optional fields", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "admin-id", email: "admin@example.com", role: "admin" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      vi.mocked(workCategoryNameExists).mockResolvedValue(false);
+
+      const mockCategory = {
+        id: "cat-id",
+        name: "Category",
+        description: null,
+        displayOrder: 0,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      vi.mocked(createWorkCategory).mockResolvedValue(mockCategory);
+
+      const request = new NextRequest("http://localhost:3000/api/work-categories", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Category",
+          // description, displayOrder, isActive not provided - should use defaults
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(createWorkCategory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Category",
+          isActive: true,
+          displayOrder: 0,
+        }),
+      );
+    });
+  });
+});

--- a/app/api/work-logs/[id]/__tests__/route.test.ts
+++ b/app/api/work-logs/[id]/__tests__/route.test.ts
@@ -1,0 +1,490 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DELETE, PUT } from "../route";
+
+// Mock the auth module
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+// Mock the repository
+vi.mock("@/lib/db/repositories/work-log-repository", () => ({
+  getWorkLogById: vi.fn(),
+  updateWorkLog: vi.fn(),
+  deleteWorkLog: vi.fn(),
+  isWorkLogOwner: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import {
+  deleteWorkLog,
+  getWorkLogById,
+  isWorkLogOwner,
+  updateWorkLog,
+} from "@/lib/db/repositories/work-log-repository";
+
+describe("PUT /api/work-logs/[id]", () => {
+  const validUuid = "123e4567-e89b-12d3-a456-426614174000";
+  const validProjectId = "550e8400-e29b-41d4-a716-446655440001";
+  const validCategoryId = "550e8400-e29b-41d4-a716-446655440002";
+
+  const mockWorkLog = {
+    id: validUuid,
+    userId: "user-id",
+    date: new Date("2024-10-05"),
+    hours: 8,
+    projectId: validProjectId,
+    categoryId: validCategoryId,
+    details: "Daily work",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when user is not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: 7.5 }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 400 for invalid UUID format", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+
+    const invalidId = "invalid-uuid";
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${invalidId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: 7.5 }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: invalidId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INVALID_ID");
+  });
+
+  it("should return 404 when work log not found", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(undefined);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: 7.5 }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 403 when non-admin user tries to update others work log", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "other-user-id",
+        email: "other@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(isWorkLogOwner).mockResolvedValue(false);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: 7.5 }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should allow user to update their own work log", async () => {
+    const updatedWorkLog = {
+      ...mockWorkLog,
+      hours: 7.5,
+      updatedAt: new Date(),
+    };
+
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(isWorkLogOwner).mockResolvedValue(true);
+    vi.mocked(updateWorkLog).mockResolvedValue(updatedWorkLog);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: "7.5" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.hours).toBe(7.5);
+  });
+
+  it("should allow admin to update any work log", async () => {
+    const updatedWorkLog = {
+      ...mockWorkLog,
+      hours: 7.5,
+      updatedAt: new Date(),
+    };
+
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(updateWorkLog).mockResolvedValue(updatedWorkLog);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: "7.5" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.hours).toBe(7.5);
+    // Admin should not need ownership check
+    expect(isWorkLogOwner).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 for invalid data", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(isWorkLogOwner).mockResolvedValue(true);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: 25 }), // Invalid: exceeds 24 hours
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("should return 500 when repository throws error", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockRejectedValue(new Error("Database error"));
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ hours: 7.5 }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INTERNAL_ERROR");
+  });
+});
+
+describe("DELETE /api/work-logs/[id]", () => {
+  const validUuid = "123e4567-e89b-12d3-a456-426614174000";
+  const validProjectId = "550e8400-e29b-41d4-a716-446655440001";
+  const validCategoryId = "550e8400-e29b-41d4-a716-446655440002";
+
+  const mockWorkLog = {
+    id: validUuid,
+    userId: "user-id",
+    date: new Date("2024-10-05"),
+    hours: 8,
+    projectId: validProjectId,
+    categoryId: validCategoryId,
+    details: "Daily work",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when user is not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 400 for invalid UUID format", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+
+    const invalidId = "invalid-uuid";
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${invalidId}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: invalidId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INVALID_ID");
+  });
+
+  it("should return 404 when work log not found", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(undefined);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 403 when non-admin user tries to delete others work log", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "other-user-id",
+        email: "other@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(isWorkLogOwner).mockResolvedValue(false);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should allow user to delete their own work log", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(isWorkLogOwner).mockResolvedValue(true);
+    vi.mocked(deleteWorkLog).mockResolvedValue(undefined);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(deleteWorkLog).toHaveBeenCalledWith(validUuid);
+  });
+
+  it("should allow admin to delete any work log", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "admin-id",
+        email: "admin@example.com",
+        role: "admin",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockResolvedValue(mockWorkLog);
+    vi.mocked(deleteWorkLog).mockResolvedValue(undefined);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(deleteWorkLog).toHaveBeenCalledWith(validUuid);
+    // Admin should not need ownership check
+    expect(isWorkLogOwner).not.toHaveBeenCalled();
+  });
+
+  it("should return 500 when repository throws error", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-id",
+        email: "user@example.com",
+        role: "user",
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    } as any);
+    vi.mocked(getWorkLogById).mockRejectedValue(new Error("Database error"));
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/work-logs/${validUuid}`,
+      {
+        method: "DELETE",
+      },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: validUuid }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/app/api/work-logs/__tests__/route.test.ts
+++ b/app/api/work-logs/__tests__/route.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * Integration tests for Work Logs API (Collection Routes)
+ * Tests GET and POST endpoints with authentication, authorization, and validation
+ */
+
+// Mock dependencies - must be before imports
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+vi.mock("@/lib/db/repositories/work-log-repository", () => ({
+  getWorkLogs: vi.fn(),
+  createWorkLog: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import { GET, POST } from "@/app/api/work-logs/route";
+import { getWorkLogs, createWorkLog } from "@/lib/db/repositories/work-log-repository";
+
+describe("Work Logs API - Collection Routes", () => {
+  const validProjectId = "550e8400-e29b-41d4-a716-446655440001";
+  const validCategoryId = "550e8400-e29b-41d4-a716-446655440002";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/work-logs", () => {
+    it("should return 401 if user is not authenticated", async () => {
+      vi.mocked(auth).mockResolvedValue(null as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should return work logs for authenticated user", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockLogs = [
+        {
+          id: "log-1",
+          userId: "user-id",
+          date: new Date("2024-10-05"),
+          hours: "8.0",
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+          details: "Daily work",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockResponse = {
+        data: mockLogs,
+        pagination: {
+          page: 1,
+          limit: 20,
+          total: 1,
+          totalPages: 1,
+        },
+      };
+
+      vi.mocked(getWorkLogs).mockResolvedValue(mockResponse);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(1);
+      expect(data.pagination).toBeDefined();
+      expect(getWorkLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-id", // Non-admin should only see own logs
+          page: 1,
+          limit: 20,
+        }),
+      );
+    });
+
+    it("should allow admin to see all work logs", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "admin-id", email: "admin@example.com", role: "admin" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockResponse = {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 20,
+          total: 0,
+          totalPages: 0,
+        },
+      };
+
+      vi.mocked(getWorkLogs).mockResolvedValue(mockResponse);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      // Admin should not have userId filter
+      expect(getWorkLogs).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          userId: expect.anything(),
+        }),
+      );
+    });
+
+    it("should support pagination parameters", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockResponse = {
+        data: [],
+        pagination: {
+          page: 2,
+          limit: 10,
+          total: 50,
+          totalPages: 5,
+        },
+      };
+
+      vi.mocked(getWorkLogs).mockResolvedValue(mockResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/work-logs?page=2&limit=10",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(getWorkLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: 2,
+          limit: 10,
+        }),
+      );
+    });
+
+    it("should return 400 for invalid pagination parameters", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/work-logs?page=0&limit=200",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should support date range filtering", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockResponse = {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 20,
+          total: 0,
+          totalPages: 0,
+        },
+      };
+
+      vi.mocked(getWorkLogs).mockResolvedValue(mockResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/work-logs?startDate=2024-10-01&endDate=2024-10-31",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(getWorkLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: expect.any(Date),
+          endDate: expect.any(Date),
+        }),
+      );
+    });
+
+    it("should support project filtering", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockResponse = {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 20,
+          total: 0,
+          totalPages: 0,
+        },
+      };
+
+      vi.mocked(getWorkLogs).mockResolvedValue(mockResponse);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/work-logs?projectId=${validProjectId}`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(getWorkLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: validProjectId,
+        }),
+      );
+    });
+  });
+
+  describe("POST /api/work-logs", () => {
+    it("should return 401 if user is not authenticated", async () => {
+      vi.mocked(auth).mockResolvedValue(null as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "2024-10-05T10:00:00+09:00",
+          hours: "8.0",
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should create work log with valid data", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockWorkLog = {
+        id: "log-id",
+        userId: "user-id",
+        date: new Date("2024-10-05"),
+        hours: "8.0",
+        projectId: validProjectId,
+        categoryId: validCategoryId,
+        details: "Daily work",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      vi.mocked(createWorkLog).mockResolvedValue(mockWorkLog);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "2024-10-05T01:00:00Z",
+          hours: "8.0",
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+          details: "Daily work",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(data.data.userId).toBe("user-id");
+      expect(createWorkLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-id",
+          hours: "8.0",
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+          details: "Daily work",
+        }),
+      );
+    });
+
+    it("should return 400 for invalid hours format", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "2024-10-05T10:00:00+09:00",
+          hours: "invalid", // Invalid hours format
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 400 for hours exceeding 24", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "2024-10-05T10:00:00+09:00",
+          hours: "25.0", // Exceeds 24 hours
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 400 for invalid project ID format", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "2024-10-05T10:00:00+09:00",
+          hours: "8.0",
+          projectId: "not-a-uuid", // Invalid UUID
+          categoryId: validCategoryId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should return 400 for invalid date format", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "invalid-date",
+          hours: "8.0",
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should allow null details", async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-id", email: "user@example.com", role: "user" },
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      } as any);
+
+      const mockWorkLog = {
+        id: "log-id",
+        userId: "user-id",
+        date: new Date("2024-10-05"),
+        hours: "8.0",
+        projectId: validProjectId,
+        categoryId: validCategoryId,
+        details: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      vi.mocked(createWorkLog).mockResolvedValue(mockWorkLog);
+
+      const request = new NextRequest("http://localhost:3000/api/work-logs", {
+        method: "POST",
+        body: JSON.stringify({
+          date: "2024-10-05T01:00:00Z",
+          hours: "8.0",
+          projectId: validProjectId,
+          categoryId: validCategoryId,
+          // details not provided
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(createWorkLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: null,
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add comprehensive integration tests for Work Categories and Work Logs API endpoints to improve test coverage and ensure API reliability.

## Changes
This PR adds 54 new integration tests across 4 test files:

### Work Categories API Tests
- **Collection Routes** (`app/api/work-categories/__tests__/route.test.ts`): 10 tests
  - GET endpoint: authentication, active/inactive filtering, query validation
  - POST endpoint: authentication, authorization (admin-only), validation, duplicate name check, default values
  
- **Item Routes** (`app/api/work-categories/[id]/__tests__/route.test.ts`): 15 tests
  - PUT endpoint: authentication, authorization, UUID validation, not found, update validation, duplicate name, displayOrder updates, database errors
  - DELETE endpoint: authentication, authorization, UUID validation, not found, soft delete, database errors

### Work Logs API Tests
- **Collection Routes** (`app/api/work-logs/__tests__/route.test.ts`): 14 tests
  - GET endpoint: authentication, user/admin access control, pagination, date filters, project filters
  - POST endpoint: authentication, validation (hours format, date format, UUID), default values
  
- **Item Routes** (`app/api/work-logs/[id]/__tests__/route.test.ts`): 15 tests
  - PUT endpoint: authentication, UUID validation, ownership checks, admin overrides, validation, database errors
  - DELETE endpoint: authentication, UUID validation, ownership checks, admin overrides, database errors

## Test Coverage
- **Total Tests**: 54 new integration tests
- **Test Results**: ✅ 144/144 tests passing (90 existing + 54 new)
- **Coverage Areas**:
  - Authentication and authorization
  - Input validation
  - Error handling
  - User ownership and admin privileges
  - Database operations

## Testing
```bash
npm run test
```

All tests pass successfully.

## Closes
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)