### PR TITLE
feat: チーム管理機能の実装 (Phase 1: Backend)

### DIFF
--- a/app/api/teams/[id]/members/[userId]/route.ts
+++ b/app/api/teams/[id]/members/[userId]/route.ts
@@ -1,0 +1,121 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { teamMembers, teams } from "@/drizzle/schema";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { db } from "@/lib/db/connection";
+
+/**
+ * DELETE /api/teams/[id]/members/[userId]
+ * Remove a member from a team
+ *
+ * Response:
+ * - 200: Member removed successfully
+ * - 401: Unauthorized
+ * - 403: Forbidden (not admin)
+ * - 404: Team or member not found
+ * - 500: Internal server error
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; userId: string }> },
+) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    // Check if user is admin
+    // TODO: Phase 2 - Allow team leaders to remove members
+    if (session.user.role !== "admin") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FORBIDDEN",
+            message: "Only admins can remove team members",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    const { id: teamId, userId } = await params;
+
+    // Check if team exists
+    const [team] = await db
+      .select()
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+
+    if (!team) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "Team not found",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Check if member exists in the team
+    const [member] = await db
+      .select()
+      .from(teamMembers)
+      .where(
+        and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)),
+      )
+      .limit(1);
+
+    if (!member) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "Member not found in this team",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Remove member from team
+    await db
+      .delete(teamMembers)
+      .where(
+        and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)),
+      );
+
+    return NextResponse.json({
+      success: true,
+    });
+  } catch (error) {
+    console.error(`DELETE /api/teams/[id]/members/[userId] error:`, error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to remove team member",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/teams/[id]/members/route.ts
+++ b/app/api/teams/[id]/members/route.ts
@@ -1,0 +1,175 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { teamMembers, teams, users } from "@/drizzle/schema";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { db } from "@/lib/db/connection";
+import { addTeamMemberSchema } from "@/lib/validations";
+
+/**
+ * POST /api/teams/[id]/members
+ * Add a member to a team
+ *
+ * Request Body:
+ * - userId: string (required, UUID)
+ * - role: 'member' | 'leader' | 'viewer' (optional, default: 'member')
+ *
+ * Response:
+ * - 201: Member added successfully
+ * - 400: Validation error or member already exists
+ * - 401: Unauthorized
+ * - 403: Forbidden (not admin)
+ * - 404: Team or user not found
+ * - 500: Internal server error
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    // Check if user is admin
+    // TODO: Phase 2 - Allow team leaders to add members
+    if (session.user.role !== "admin") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FORBIDDEN",
+            message: "Only admins can add team members",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    const { id: teamId } = await params;
+
+    // Check if team exists
+    const [team] = await db
+      .select()
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+
+    if (!team) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "Team not found",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Parse and validate request body
+    const body = await request.json();
+    const validatedData = addTeamMemberSchema.parse(body);
+
+    // Check if user exists
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, validatedData.userId))
+      .limit(1);
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "User not found",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Check if user is already a member of this team
+    const [existingMember] = await db
+      .select()
+      .from(teamMembers)
+      .where(
+        and(
+          eq(teamMembers.teamId, teamId),
+          eq(teamMembers.userId, validatedData.userId),
+        ),
+      )
+      .limit(1);
+
+    if (existingMember) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "ALREADY_MEMBER",
+            message: "User is already a member of this team",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    // Add member to team
+    const [newMember] = await db
+      .insert(teamMembers)
+      .values({
+        teamId,
+        userId: validatedData.userId,
+        role: validatedData.role,
+      })
+      .returning();
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: newMember,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error(`POST /api/teams/[id]/members error:`, error);
+
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request data",
+            details: error,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to add team member",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/teams/[id]/route.ts
+++ b/app/api/teams/[id]/route.ts
@@ -1,0 +1,334 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { teamMembers, teams, users } from "@/drizzle/schema";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { db } from "@/lib/db/connection";
+import { updateTeamSchema } from "@/lib/validations";
+
+/**
+ * GET /api/teams/[id]
+ * Get team details with members list
+ *
+ * Response:
+ * - 200: Success with team details and members
+ * - 401: Unauthorized
+ * - 404: Team not found
+ * - 500: Internal server error
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    const { id: teamId } = await params;
+
+    // Get team details
+    const [team] = await db
+      .select()
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+
+    if (!team) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "Team not found",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Get team members with user information
+    const members = await db
+      .select({
+        id: teamMembers.id,
+        userId: teamMembers.userId,
+        userName: users.name,
+        userEmail: users.email,
+        role: teamMembers.role,
+        joinedAt: teamMembers.joinedAt,
+      })
+      .from(teamMembers)
+      .innerJoin(users, eq(teamMembers.userId, users.id))
+      .where(eq(teamMembers.teamId, teamId))
+      .orderBy(teamMembers.joinedAt);
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        ...team,
+        members,
+      },
+    });
+  } catch (error) {
+    console.error(`GET /api/teams/[id] error:`, error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to retrieve team details",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * PUT /api/teams/[id]
+ * Update team information
+ *
+ * Request Body:
+ * - name: string (optional)
+ * - description: string (optional)
+ * - isActive: boolean (optional)
+ *
+ * Response:
+ * - 200: Team updated successfully
+ * - 400: Validation error or duplicate name
+ * - 401: Unauthorized
+ * - 403: Forbidden (not admin)
+ * - 404: Team not found
+ * - 500: Internal server error
+ */
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    // Check if user is admin
+    if (session.user.role !== "admin") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FORBIDDEN",
+            message: "Only admins can update teams",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    const { id: teamId } = await params;
+
+    // Check if team exists
+    const [existingTeam] = await db
+      .select()
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+
+    if (!existingTeam) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "Team not found",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Parse and validate request body
+    const body = await request.json();
+    const validatedData = updateTeamSchema.parse(body);
+
+    // If name is being updated, check for duplicates
+    if (validatedData.name && validatedData.name !== existingTeam.name) {
+      const [duplicateTeam] = await db
+        .select()
+        .from(teams)
+        .where(eq(teams.name, validatedData.name))
+        .limit(1);
+
+      if (duplicateTeam) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "DUPLICATE_NAME",
+              message: "A team with this name already exists",
+            },
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Update team
+    const [updatedTeam] = await db
+      .update(teams)
+      .set({
+        ...validatedData,
+        updatedAt: new Date(),
+      })
+      .where(eq(teams.id, teamId))
+      .returning();
+
+    return NextResponse.json({
+      success: true,
+      data: updatedTeam,
+    });
+  } catch (error) {
+    console.error(`PUT /api/teams/[id] error:`, error);
+
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request data",
+            details: error,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to update team",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/teams/[id]
+ * Soft delete a team (set isActive to false)
+ *
+ * Response:
+ * - 200: Team deleted successfully
+ * - 401: Unauthorized
+ * - 403: Forbidden (not admin)
+ * - 404: Team not found
+ * - 500: Internal server error
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    // Check if user is admin
+    if (session.user.role !== "admin") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FORBIDDEN",
+            message: "Only admins can delete teams",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    const { id: teamId } = await params;
+
+    // Check if team exists
+    const [existingTeam] = await db
+      .select()
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+
+    if (!existingTeam) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "Team not found",
+          },
+        },
+        { status: 404 },
+      );
+    }
+
+    // Soft delete team (set isActive to false)
+    await db
+      .update(teams)
+      .set({
+        isActive: false,
+        updatedAt: new Date(),
+      })
+      .where(eq(teams.id, teamId));
+
+    return NextResponse.json({
+      success: true,
+    });
+  } catch (error) {
+    console.error(`DELETE /api/teams/[id] error:`, error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to delete team",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -1,0 +1,214 @@
+import { count, eq, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { teamMembers, teams } from "@/drizzle/schema";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { db } from "@/lib/db/connection";
+import { createTeamSchema, listTeamsQuerySchema } from "@/lib/validations";
+
+/**
+ * GET /api/teams
+ * Get all teams (or only active teams based on query parameter)
+ *
+ * Query Parameters:
+ * - active: 'true' to get only active teams
+ *
+ * Response:
+ * - 200: Success with teams list and member counts
+ * - 401: Unauthorized
+ * - 500: Internal server error
+ */
+export async function GET(request: Request) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    // Parse and validate query parameters
+    const { searchParams } = new URL(request.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const { active } = listTeamsQuerySchema.parse(queryParams);
+
+    // Build query
+    const conditions = [];
+    if (active !== undefined) {
+      conditions.push(eq(teams.isActive, active));
+    }
+
+    // Get teams with member counts
+    const teamsList = await db
+      .select({
+        id: teams.id,
+        name: teams.name,
+        description: teams.description,
+        isActive: teams.isActive,
+        createdAt: teams.createdAt,
+        updatedAt: teams.updatedAt,
+        memberCount: count(teamMembers.id),
+      })
+      .from(teams)
+      .leftJoin(teamMembers, eq(teams.id, teamMembers.teamId))
+      .where(conditions.length > 0 ? sql`${conditions[0]}` : undefined)
+      .groupBy(teams.id)
+      .orderBy(teams.name);
+
+    return NextResponse.json({
+      success: true,
+      data: teamsList,
+    });
+  } catch (error) {
+    console.error("GET /api/teams error:", error);
+
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid query parameters",
+            details: error,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to retrieve teams",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/teams
+ * Create a new team
+ *
+ * Request Body:
+ * - name: string (required, unique)
+ * - description: string (optional)
+ *
+ * Response:
+ * - 201: Team created successfully
+ * - 400: Validation error or duplicate name
+ * - 401: Unauthorized
+ * - 403: Forbidden (not admin or manager)
+ * - 500: Internal server error
+ */
+export async function POST(request: Request) {
+  try {
+    // Authenticate user
+    const session = await getAuthenticatedSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    // Check if user has permission (admin or manager)
+    if (session.user.role !== "admin" && session.user.role !== "manager") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FORBIDDEN",
+            message: "Only admins and managers can create teams",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    // Parse and validate request body
+    const body = await request.json();
+    const validatedData = createTeamSchema.parse(body);
+
+    // Check if team with same name already exists
+    const existingTeam = await db
+      .select()
+      .from(teams)
+      .where(eq(teams.name, validatedData.name))
+      .limit(1);
+
+    if (existingTeam.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "DUPLICATE_NAME",
+            message: "A team with this name already exists",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    // Create team
+    const [newTeam] = await db
+      .insert(teams)
+      .values({
+        name: validatedData.name,
+        description: validatedData.description ?? null,
+        isActive: true,
+      })
+      .returning();
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: newTeam,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error("POST /api/teams error:", error);
+
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request data",
+            details: error,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to create team",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/drizzle/migrations/0003_dry_sinister_six.sql
+++ b/drizzle/migrations/0003_dry_sinister_six.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "team_members" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"team_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" varchar(50) DEFAULT 'member' NOT NULL,
+	"joined_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "team_members_team_user_unique" UNIQUE("team_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "teams" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "teams_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "team_members_team_user_idx" ON "team_members" USING btree ("team_id","user_id");--> statement-breakpoint
+CREATE INDEX "team_members_user_idx" ON "team_members" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "teams_is_active_idx" ON "teams" USING btree ("is_active");

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "a9ddbef2-2abe-4beb-849f-5ea7c5b6af82",
-  "prevId": "1eb117a9-7fef-479e-b7d0-12a2b8c0df6a",
+  "id": "13742e8f-04d1-44c1-9675-32158680da4e",
+  "prevId": "a9ddbef2-2abe-4beb-849f-5ea7c5b6af82",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -210,6 +210,203 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_idx": {
+          "name": "team_members_team_user_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_user_unique": {
+          "name": "team_members_team_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_is_active_idx": {
+          "name": "teams_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_unique": {
+          "name": "teams_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1759628692271,
       "tag": "0002_thin_bruce_banner",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1761443980021,
+      "tag": "0003_dry_sinister_six",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,0 +1,98 @@
+import { eq } from "drizzle-orm";
+import { teamMembers } from "@/drizzle/schema";
+import { db } from "@/lib/db/connection";
+
+/**
+ * Check if two users are teammates (belong to the same team)
+ *
+ * @param userId1 - First user's ID
+ * @param userId2 - Second user's ID
+ * @returns True if users are in the same team, false otherwise
+ */
+export async function checkIfTeammates(
+  userId1: string,
+  userId2: string,
+): Promise<boolean> {
+  if (userId1 === userId2) return true;
+
+  // Get all team IDs for user1
+  const user1Teams = await db
+    .select({ teamId: teamMembers.teamId })
+    .from(teamMembers)
+    .where(eq(teamMembers.userId, userId1));
+
+  if (user1Teams.length === 0) return false;
+
+  const teamIds = user1Teams.map((t) => t.teamId);
+
+  // Check if user2 belongs to any of those teams
+  const user2Teams = await db
+    .select({ teamId: teamMembers.teamId })
+    .from(teamMembers)
+    .where(eq(teamMembers.userId, userId2));
+
+  const commonTeams = user2Teams.filter((t) => teamIds.includes(t.teamId));
+
+  return commonTeams.length > 0;
+}
+
+/**
+ * Check if a user can view a work log
+ *
+ * Permission rules:
+ * 1. Admin can view all work logs
+ * 2. User can view their own work logs
+ * 3. User can view work logs of their teammates
+ *
+ * @param viewerUserId - ID of the user who wants to view
+ * @param targetUserId - ID of the user whose work log is being viewed
+ * @param viewerRole - Role of the viewer ('admin', 'manager', 'user')
+ * @returns True if viewer can view the work log, false otherwise
+ */
+export async function canViewWorkLog(
+  viewerUserId: string,
+  targetUserId: string,
+  viewerRole: string,
+): Promise<boolean> {
+  // 1. Admin can view all
+  if (viewerRole === "admin") return true;
+
+  // 2. User can view their own
+  if (viewerUserId === targetUserId) return true;
+
+  // 3. Check if users are teammates
+  const isTeammate = await checkIfTeammates(viewerUserId, targetUserId);
+  if (isTeammate) return true;
+
+  // 4. Otherwise, deny access
+  return false;
+}
+
+/**
+ * Check if a user can edit a work log
+ *
+ * Permission rules:
+ * 1. Admin can edit all work logs
+ * 2. User can edit their own work logs
+ * 3. Team leaders cannot edit other members' work logs (Phase 1)
+ *
+ * @param editorUserId - ID of the user who wants to edit
+ * @param targetUserId - ID of the user whose work log is being edited
+ * @param editorRole - Role of the editor ('admin', 'manager', 'user')
+ * @returns True if editor can edit the work log, false otherwise
+ */
+export async function canEditWorkLog(
+  editorUserId: string,
+  targetUserId: string,
+  editorRole: string,
+): Promise<boolean> {
+  // 1. Admin can edit all
+  if (editorRole === "admin") return true;
+
+  // 2. User can edit their own
+  if (editorUserId === targetUserId) return true;
+
+  // 3. Phase 1: No other editing permissions
+  // TODO: Phase 2 - Add team leader editing permissions
+  return false;
+}

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -279,3 +279,60 @@ export type WorkLogSearchQuery = z.infer<typeof workLogSearchSchema>;
 // Enhanced type exports for better type safety
 export type WorkLogSearchParams = z.input<typeof workLogSearchSchema>;
 export type WorkLogSearchValidated = z.output<typeof workLogSearchSchema>;
+
+/**
+ * Team Validation Schemas
+ */
+
+// Create team schema
+export const createTeamSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Team name is required")
+    .max(255, "Team name must be 255 characters or less")
+    .trim(),
+  description: z.string().optional().nullable(),
+});
+
+// Update team schema
+export const updateTeamSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Team name is required")
+    .max(255, "Team name must be 255 characters or less")
+    .trim()
+    .optional(),
+  description: z.string().optional().nullable(),
+  isActive: z.boolean().optional(),
+});
+
+// Query parameters for listing teams
+export const listTeamsQuerySchema = z.object({
+  active: z
+    .string()
+    .optional()
+    .transform((val) => val === "true")
+    .pipe(z.boolean()),
+});
+
+/**
+ * Team Member Validation Schemas
+ */
+
+// Add team member schema
+export const addTeamMemberSchema = z.object({
+  userId: z.string().uuid("Invalid user ID"),
+  role: z
+    .enum(["member", "leader", "viewer"], {
+      message: "Role must be 'member', 'leader', or 'viewer'",
+    })
+    .default("member"),
+});
+
+/**
+ * Type exports for Teams
+ */
+export type CreateTeamInput = z.infer<typeof createTeamSchema>;
+export type UpdateTeamInput = z.infer<typeof updateTeamSchema>;
+export type ListTeamsQuery = z.infer<typeof listTeamsQuerySchema>;
+export type AddTeamMemberInput = z.infer<typeof addTeamMemberSchema>;


### PR DESCRIPTION
## 概要

Issue #72 のPhase 1（バックエンド）として、チーム管理機能の基盤を実装しました。

## 実装内容

### データベーススキーマ
- ✅ `teams` テーブルの作成
  - チーム情報を管理（id, name, description, isActive, timestamps）
  - ユニーク制約: name
  - インデックス: is_active
- ✅ `team_members` テーブルの作成
  - チームとユーザーの多対多関係を管理
  - role フィールド（member, leader, viewer）
  - ユニーク制約: (teamId, userId)
  - インデックス: (teamId, userId), userId
  - カスケード削除設定

### 権限管理ロジック
- ✅ `canViewWorkLog()` - 工数参照権限チェック
  - 管理者: 全て参照可能
  - ユーザー: 自分の工数 + チームメンバーの工数
- ✅ `canEditWorkLog()` - 工数編集権限チェック
  - 管理者: 全て編集可能
  - ユーザー: 自分の工数のみ編集可能
- ✅ `checkIfTeammates()` - チームメンバーシップ確認

### チーム管理API
- ✅ `GET /api/teams` - チーム一覧取得
  - クエリパラメータ: `active=true` でアクティブなチームのみ
  - レスポンス: チーム情報 + メンバー数
- ✅ `POST /api/teams` - チーム作成（admin/manager のみ）
  - バリデーション: name（必須・ユニーク）
  - 重複チェック
- ✅ `GET /api/teams/[id]` - チーム詳細取得
  - チーム情報 + メンバー一覧（ユーザー情報含む）
- ✅ `PUT /api/teams/[id]` - チーム更新（admin のみ）
  - name の重複チェック
- ✅ `DELETE /api/teams/[id]` - チーム削除（論理削除、admin のみ）

### チームメンバー管理API
- ✅ `POST /api/teams/[id]/members` - メンバー追加（admin のみ）
  - バリデーション: userId, role
  - 重複メンバーチェック
  - ユーザー存在確認
- ✅ `DELETE /api/teams/[id]/members/[userId]` - メンバー削除（admin のみ）

### バリデーション
- ✅ Zodスキーマの追加
  - `createTeamSchema`
  - `updateTeamSchema`
  - `listTeamsQuerySchema`
  - `addTeamMemberSchema`

## 技術的な詳細

### セキュリティ
- 全APIエンドポイントで認証チェック実施
- 役割ベースのアクセス制御（admin, manager, user）
- SQLインジェクション対策（Drizzle ORMの型安全性）

### パフォーマンス
- 適切なインデックス設定
  - teams: is_active
  - team_members: (team_id, user_id), user_id
- JOIN最適化（メンバー一覧取得時）

### コード品質
- ✅ TypeScript型チェック通過
- ✅ Biome lint通過
- 一貫したエラーハンドリング
- 適切なHTTPステータスコード

## テスト

現時点ではバックエンドテストは未実装です。Issue #72 のPhase 3で追加予定です。

## 残りの作業（Issue #72）

### Phase 2: 工数取得API拡張
- [ ] `GET /api/work-logs` に `scope` パラメータ追加
  - `scope=own`: 自分の工数のみ
  - `scope=team`: チームメンバーの工数含む
  - `scope=all`: 全体（admin のみ）
- [ ] レスポンスにユーザー情報追加

### Phase 3: フロントエンド実装
- [ ] `/teams` ページ（チーム一覧）
- [ ] `/teams/[id]` ページ（チーム詳細・メンバー管理）
- [ ] `/work-logs` ページのスコープ切り替え機能

### Phase 4: テスト
- [ ] ユニットテスト（権限チェック関数）
- [ ] 統合テスト（API エンドポイント）
- [ ] E2Eテスト

## 関連Issue

Closes #72 (Phase 1のみ)

## マイグレーション

データベースマイグレーションが含まれています：
- `drizzle/migrations/0003_dry_sinister_six.sql`

マイグレーションは CI/CD パイプラインで自動適用されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)