### PR TITLE
feat: ダッシュボード工数カードラベルを期間選択に応じて動的に変更 (Issue #149)

### DIFF
--- a/app/[locale]/dashboard/_components/dashboard-content.tsx
+++ b/app/[locale]/dashboard/_components/dashboard-content.tsx
@@ -171,7 +171,7 @@ export function DashboardContent() {
     return (
       <>
         {/* Summary Cards */}
-        <PersonalSummaryCard summary={stats.summary} />
+        <PersonalSummaryCard summary={stats.summary} period={period} />
 
         {/* User Distribution Chart (only when scope is "all") */}
         {effectiveScope === "all" &&

--- a/app/[locale]/dashboard/_components/personal-summary-card.tsx
+++ b/app/[locale]/dashboard/_components/personal-summary-card.tsx
@@ -1,51 +1,64 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { PersonalSummary } from "./types";
+import type { PeriodType, PersonalSummary } from "./types";
 
 interface PersonalSummaryCardProps {
   summary: PersonalSummary;
+  period: PeriodType;
 }
 
-export function PersonalSummaryCard({ summary }: PersonalSummaryCardProps) {
+export function PersonalSummaryCard({
+  summary,
+  period,
+}: PersonalSummaryCardProps) {
+  const t = useTranslations("dashboard.cards");
+
   return (
     <div className="grid gap-4 md:grid-cols-3">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">今日の工数</CardTitle>
+          <CardTitle className="text-sm font-medium">
+            {t(`${period}.card1`)}
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{summary.today.totalHours}h</div>
           <p className="text-xs text-muted-foreground">
-            {summary.today.logCount}件の記録
+            {t("logCount", { count: summary.today.logCount })}
           </p>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">今週の工数</CardTitle>
+          <CardTitle className="text-sm font-medium">
+            {t(`${period}.card2`)}
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
             {summary.thisWeek.totalHours}h
           </div>
           <p className="text-xs text-muted-foreground">
-            {summary.thisWeek.logCount}件の記録
+            {t("logCount", { count: summary.thisWeek.logCount })}
           </p>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">今月の工数</CardTitle>
+          <CardTitle className="text-sm font-medium">
+            {t(`${period}.card3`)}
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
             {summary.thisMonth.totalHours}h
           </div>
           <p className="text-xs text-muted-foreground">
-            {summary.thisMonth.logCount}件の記録
+            {t("logCount", { count: summary.thisMonth.logCount })}
           </p>
         </CardContent>
       </Card>

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -213,6 +213,39 @@
     "error": {
       "title": "エラーが発生しました",
       "fetchFailed": "ダッシュボードデータの取得に失敗しました: {message}"
+    },
+    "cards": {
+      "today": {
+        "card1": "今日の工数",
+        "card2": "今週の工数",
+        "card3": "今月の工数"
+      },
+      "week": {
+        "card1": "今週の平均",
+        "card2": "今週の工数",
+        "card3": "今月の工数"
+      },
+      "month": {
+        "card1": "今月の平均",
+        "card2": "今月の工数",
+        "card3": "今月の工数"
+      },
+      "lastWeek": {
+        "card1": "先週の平均",
+        "card2": "先週の工数",
+        "card3": "先週の工数"
+      },
+      "lastMonth": {
+        "card1": "先月の平均",
+        "card2": "先月の工数",
+        "card3": "先月の工数"
+      },
+      "custom": {
+        "card1": "期間の平均",
+        "card2": "期間の工数",
+        "card3": "期間の工数"
+      },
+      "logCount": "{count}件の記録"
     }
   },
   "workLogs": {


### PR DESCRIPTION
## 概要

ダッシュボードの工数カード（サマリーカード）のラベルを、期間選択に応じて動的に変更する機能を実装しました。

Closes #149

## 変更内容

### 1. i18n 翻訳の追加 (`messages/ja.json`)

各期間タイプに対応するカードラベルの翻訳を追加:

| 選択期間 | カード1 | カード2 | カード3 |
|---------|---------|---------|---------|
| 今日 | 今日の工数 | 今週の工数 | 今月の工数 |
| 今週 | 今週の平均 | 今週の工数 | 今月の工数 |
| 今月 | 今月の平均 | 今月の工数 | 今月の工数 |
| 先週 | 先週の平均 | 先週の工数 | 先週の工数 |
| 先月 | 先月の平均 | 先月の工数 | 先月の工数 |
| カスタム | 期間の平均 | 期間の工数 | 期間の工数 |

### 2. PersonalSummaryCard コンポーネントの更新

- `period: PeriodType` props を追加
- `useTranslations` フックを使用して動的にラベルを生成
- ハードコードされていたラベルを翻訳キーベースに変更

### 3. DashboardContent コンポーネントの更新

- `PersonalSummaryCard` に現在選択中の `period` を渡すように変更

## 技術的詳細

### 実装アプローチ

- **フロントエンドのみの変更**: APIレスポンスは変更せず、ラベル表示のみを動的化
- **i18n対応**: next-intl を使用した完全な国際化対応
- **型安全性**: TypeScript で period の型を厳密に管理

### 影響範囲

- ✅ 既存の機能に影響なし
- ✅ APIは変更なし
- ✅ データ構造は変更なし
- ✅ UIラベルのみ動的化

## テスト

- ✅ Lint チェック通過 (`pnpm run lint`)
- ✅ 型チェック通過 (`pnpm run type-check`)
- ✅ 既存テストへの影響なし

## スクリーンショット

期間選択を変更すると、カードラベルが自動的に更新されます:
- 「今週」選択時: "今週の平均" / "今週の工数" / "今月の工数"
- 「先月」選択時: "先月の平均" / "先月の工数" / "先月の工数"
- 「カスタム」選択時: "期間の平均" / "期間の工数" / "期間の工数"

## レビューポイント

1. 翻訳の内容が適切か（日本語として自然か）
2. 期間ごとのラベル分け方が直感的か
3. UX的に分かりやすい表示になっているか

## 関連Issue

- Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)