### PR TITLE
feat: ダッシュボード工数カードのデータを期間選択に応じて動的に取得 (Issue #153)

### DIFF
--- a/app/[locale]/dashboard/_components/personal-summary-card.tsx
+++ b/app/[locale]/dashboard/_components/personal-summary-card.tsx
@@ -24,9 +24,9 @@ export function PersonalSummaryCard({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{summary.today.totalHours}h</div>
+          <div className="text-2xl font-bold">{summary.card1.totalHours}h</div>
           <p className="text-xs text-muted-foreground">
-            {t("logCount", { count: summary.today.logCount })}
+            {t("logCount", { count: summary.card1.logCount })}
           </p>
         </CardContent>
       </Card>
@@ -38,11 +38,9 @@ export function PersonalSummaryCard({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">
-            {summary.thisWeek.totalHours}h
-          </div>
+          <div className="text-2xl font-bold">{summary.card2.totalHours}h</div>
           <p className="text-xs text-muted-foreground">
-            {t("logCount", { count: summary.thisWeek.logCount })}
+            {t("logCount", { count: summary.card2.logCount })}
           </p>
         </CardContent>
       </Card>
@@ -54,11 +52,9 @@ export function PersonalSummaryCard({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">
-            {summary.thisMonth.totalHours}h
-          </div>
+          <div className="text-2xl font-bold">{summary.card3.totalHours}h</div>
           <p className="text-xs text-muted-foreground">
-            {t("logCount", { count: summary.thisMonth.logCount })}
+            {t("logCount", { count: summary.card3.logCount })}
           </p>
         </CardContent>
       </Card>

--- a/app/[locale]/dashboard/_components/types.ts
+++ b/app/[locale]/dashboard/_components/types.ts
@@ -2,23 +2,17 @@
  * Dashboard component types
  */
 
+export interface PeriodStats {
+  totalHours: string;
+  logCount: number;
+  periodStart?: string;
+  periodEnd?: string;
+}
+
 export interface PersonalSummary {
-  today: {
-    totalHours: string;
-    logCount: number;
-  };
-  thisWeek: {
-    totalHours: string;
-    logCount: number;
-    weekStart: string;
-    weekEnd: string;
-  };
-  thisMonth: {
-    totalHours: string;
-    logCount: number;
-    monthStart: string;
-    monthEnd: string;
-  };
+  card1: PeriodStats;
+  card2: PeriodStats;
+  card3: PeriodStats;
 }
 
 export interface ProjectDistribution {


### PR DESCRIPTION
## 概要

Issue #149 でダッシュボード工数カードのラベルが期間選択に応じて動的に変更されるようになりましたが、表示されているデータは常に固定（今日・今週・今月）でした。本PRでは、期間選択に応じて適切なデータを取得・表示するよう実装しました。

Closes #153

## 変更内容

### 1. 型定義の更新 (`types.ts`)

**Before:**
```typescript
export interface PersonalSummary {
  today: { totalHours: string; logCount: number };
  thisWeek: { totalHours: string; logCount: number; weekStart: string; weekEnd: string };
  thisMonth: { totalHours: string; logCount: number; monthStart: string; monthEnd: string };
}
```

**After:**
```typescript
export interface PeriodStats {
  totalHours: string;
  logCount: number;
  periodStart?: string;
  periodEnd?: string;
}

export interface PersonalSummary {
  card1: PeriodStats;
  card2: PeriodStats;
  card3: PeriodStats;
}
```

### 2. Repository の更新 (`dashboard-repository.ts`)

期間選択に応じた動的なデータ計算ロジックを実装：

**カード1: 1日平均**
- 計算式: `総工数 ÷ 営業日数`
- 営業日数: 実際に記録がある日数（`COUNT(DISTINCT date)`）

**カード2: 総工数 または 1週平均**
- 今日/今週/先週: 総工数をそのまま表示
- 今月/先月/カスタム: `総工数 ÷ 週数`

**カード3: 総工数**
- 選択期間の総工数

### 3. フロントエンドの更新 (`personal-summary-card.tsx`)

固定フィールド参照から動的参照に変更：

**Before:**
```typescript
<div>{summary.today.totalHours}h</div>
<div>{summary.thisWeek.totalHours}h</div>
<div>{summary.thisMonth.totalHours}h</div>
```

**After:**
```typescript
<div>{summary.card1.totalHours}h</div>
<div>{summary.card2.totalHours}h</div>
<div>{summary.card3.totalHours}h</div>
```

## 期間ごとのデータ表示

| 選択期間 | カード1 | カード2 | カード3 |
|---------|---------|---------|---------|
| 今日 | 今日の工数 | 今週の工数 | 今月の工数 |
| 今週 | 今週の1日平均 | 今週の工数 | 今月の工数 |
| **今月** | 今月の1日平均 | **今月の1週平均** | 今月の工数 |
| 先週 | 先週の1日平均 | 先週の工数 | 先週の工数 |
| **先月** | 先月の1日平均 | **先月の1週平均** | 先月の工数 |
| **カスタム** | 期間の1日平均 | **期間の1週平均** | 期間の工数 |

## 計算例

### 先月を選択した場合（30日間、実働20日、総工数150時間）

- **カード1（1日平均）**: 150h ÷ 20日 = 7.5h/日
- **カード2（1週平均）**: 150h ÷ 4.3週 = 34.9h/週
- **カード3（総工数）**: 150h

## 技術的詳細

### 営業日数の計算
```sql
COUNT(DISTINCT ${workLogs.date})::int
```
実際に工数が記録されている日数のみをカウント（休日や記録がない日を除外）

### 週数の計算
```typescript
const periodDays = Math.ceil(
  (periodEnd.getTime() - periodStart.getTime()) / (1000 * 60 * 60 * 24)
);
const weeks = Math.max(1, Math.ceil(periodDays / 7));
```

## テスト

- ✅ Lint チェック通過 (`pnpm run lint`)
- ✅ 型チェック通過 (`pnpm run type-check`)
- ✅ Biome フォーマット適用済み

## 影響範囲

- ✅ 既存機能への影響なし
- ✅ API の型定義変更あり（PersonalSummary）
- ✅ 下位互換性: なし（型定義が変更されているため、関連コンポーネントも更新が必要）

## レビューポイント

1. 計算ロジックが正しいか（特に週数の計算方法）
2. 1日平均と1週平均の使い分けが適切か
3. 期間選択ごとのデータ表示が直感的か
4. 型定義の変更が適切か

## 関連PR

- #152 - ダッシュボード工数カードラベルを期間選択に応じて動的に変更 (Issue #149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)